### PR TITLE
Create test database and database connection setup

### DIFF
--- a/database_connection.rb
+++ b/database_connection.rb
@@ -1,0 +1,15 @@
+require 'pg'
+
+class DatabaseConnection
+  def self.setup(dbname)
+    @connection = PG.connect(dbname: dbname)
+  end
+
+  def self.connection
+    @connection
+  end
+
+  def self.query(sql)
+    @connection.exec(sql)
+  end
+end

--- a/database_connection_setup.rb
+++ b/database_connection_setup.rb
@@ -1,0 +1,7 @@
+require './database_connection'
+
+if ENV['ENVIRONMENT'] == 'test'
+  DatabaseConnection.setup('makersbnb_test')
+else
+  DatabaseConnection.setup('makersbnb')
+end

--- a/spec/database_connection_spec.rb
+++ b/spec/database_connection_spec.rb
@@ -1,0 +1,24 @@
+require 'database_connection'
+
+describe DatabaseConnection do
+  describe '.setup' do
+    it 'sets up a connection to a database through PG' do
+      expect(PG).to receive(:connect).with(dbname: 'makersbnb_test')
+      DatabaseConnection.setup('makersbnb_test')
+    end
+
+    it 'this connection is persistent' do
+      connection = DatabaseConnection.setup('makersbnb_test')
+
+      expect(DatabaseConnection.connection).to eq connection
+    end
+  end
+
+  describe '.query' do
+    it 'executes a query via PG' do
+      connection = DatabaseConnection.setup('makersbnb_test')
+      expect(connection).to receive(:exec).with("SELECT * FROM users;")
+      DatabaseConnection.query("SELECT * FROM users;")
+    end
+  end
+end

--- a/spec/setup_test_database.rb
+++ b/spec/setup_test_database.rb
@@ -1,0 +1,8 @@
+require 'pg'
+
+def setup_test_database
+  connection = PG.connect(dbname: 'makersbnb_test')
+  connection.exec("TRUNCATE users;")
+  connection.exec("TRUNCATE spaces;")
+  connection.exec("TRUNCATE bookings;")
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@
 
 # Set the environment to "test"
 ENV['RACK_ENV'] = 'test'
+ENV['ENVIRONMENT'] = 'test'
 
 # Bring in the contents of the `app.rb` file. The below is equivalent to: require_relative '../app.rb'
 require File.join(File.dirname(__FILE__), '..', 'app.rb')
@@ -27,6 +28,12 @@ require 'rspec'
 
 # Tell Capybara to talk to BookmarkManager
 Capybara.app = MakersBnb
+
+RSpec.configure do |config|
+  config.before(:each) do
+    setup_test_database
+  end
+end
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
-I created a test DB to mirror the actual DB, using the SQL queries in the DB folder.
-I set up the spec_helper so that the tests are run on the test DB rather than the actual one. 